### PR TITLE
Default-init all class members

### DIFF
--- a/MVerb.h
+++ b/MVerb.h
@@ -29,17 +29,39 @@ template<typename T>
 class MVerb
 {
 private:
-    Allpass<T, 96000> allpass[4];
-    StaticAllpassFourTap<T, 96000> allpassFourTap[4];
-    StateVariable<T,4> bandwidthFilter[2];
-    StateVariable<T,4> damping[2];
-    StaticDelayLine<T, 96000> predelay;
-    StaticDelayLineFourTap<T, 96000> staticDelayLine[4];
-    StaticDelayLineEightTap<T, 96000> earlyReflectionsDelayLine[2];
-    T SampleRate, DampingFreq, Density1, Density2, BandwidthFreq, PreDelayTime, Decay, Gain, Mix, EarlyMix, Size;
-    T MixSmooth, EarlyLateSmooth, BandwidthSmooth, DampingSmooth, PredelaySmooth, SizeSmooth, DensitySmooth, DecaySmooth;
-    T PreviousLeftTank, PreviousRightTank;
-    int ControlRate, ControlRateCounter;
+    Allpass<T, 96000> allpass[4] = {};
+    StaticAllpassFourTap<T, 96000> allpassFourTap[4] = {};
+    StateVariable<T,4> bandwidthFilter[2] = {};
+    StateVariable<T,4> damping[2] = {};
+    StaticDelayLine<T, 96000> predelay = {};
+    StaticDelayLineFourTap<T, 96000> staticDelayLine[4] = {};
+    StaticDelayLineEightTap<T, 96000> earlyReflectionsDelayLine[2] = {};
+    T SampleRate = {};
+    T DampingFreq = {};
+    T Density1 = {};
+    T Density2 = {};
+    T BandwidthFreq = {};
+    T PreDelayTime = {};
+    T Decay = {};
+    T Gain = {};
+    T Mix = {};
+    T EarlyMix = {};
+    T Size = {};
+
+    T MixSmooth = {};
+    T EarlyLateSmooth = {};
+    T BandwidthSmooth = {};
+    T DampingSmooth = {};
+    T PredelaySmooth = {};
+    T SizeSmooth = {};
+    T DensitySmooth = {};
+    T DecaySmooth = {};
+
+    T PreviousLeftTank = {};
+    T PreviousRightTank = {};
+
+    int ControlRate = 0;
+    int ControlRateCounter = 0;
 
 public:
     enum
@@ -336,10 +358,10 @@ template<typename T, int maxLength>
 class Allpass
 {
 private:
-    T buffer[maxLength];
-	int index;
-	int Length;
-	T Feedback;
+    T buffer[maxLength] = {};
+    int index = 0;
+    int Length = 0;
+    T Feedback = {};
 
 public:
     Allpass()
@@ -393,10 +415,13 @@ template<typename T, int maxLength>
 class StaticAllpassFourTap
 {
 private:
-    T buffer[maxLength];
-	int index1, index2, index3, index4;
-	int Length;
-	T Feedback;
+    T buffer[maxLength] = {};
+    int index1 = 0;
+    int index2 = 0;
+    int index3 = 0;
+    int index4 = 0;
+    int Length = 0;
+    T Feedback = {};
 
 public:
     StaticAllpassFourTap()
@@ -492,10 +517,10 @@ template<typename T, int maxLength>
 class StaticDelayLine
 {
 private:
-    T buffer[maxLength];
-	int index;
-	int Length;
-	T Feedback;
+    T buffer[maxLength] = {};
+    int index = 0;
+    int Length = 0;
+    T Feedback = {};
 
 public:
     StaticDelayLine()
@@ -540,10 +565,13 @@ template<typename T, int maxLength>
 class StaticDelayLineFourTap
 {
 private:
-    T buffer[maxLength];
-	int index1, index2, index3, index4;
-	int Length;
-	T Feedback;
+    T buffer[maxLength] = {};
+    int index1 = 0;
+    int index2 = 0;
+    int index3 = 0;
+    int index4 = 0;
+    int Length = 0;
+    T Feedback = {};
 
 public:
     StaticDelayLineFourTap()
@@ -629,10 +657,17 @@ template<typename T, int maxLength>
 class StaticDelayLineEightTap
 {
 private:
-    T buffer[maxLength];
-	int index1, index2, index3, index4, index5, index6, index7, index8;
-	int Length;
-	T Feedback;
+    T buffer[maxLength] = {};
+    int index1 = 0;
+    int index2 = 0;
+    int index3 = 0;
+    int index4 = 0;
+    int index5 = 0;
+    int index6 = 0;
+    int index7 = 0;
+    int index8 = 0;
+    int Length = 0;;
+    T Feedback = {};
 
 public:
     StaticDelayLineEightTap()
@@ -754,17 +789,17 @@ template<typename T, int OverSampleCount>
 
     private:
 
-        T sampleRate;
-        T frequency;
-        T q;
-        T f;
+        T sampleRate = {};
+        T frequency = {};
+        T q = {};
+        T f = {};
 
-        T low;
-        T high;
-        T band;
-        T notch;
+        T low = {};
+        T high = {};
+        T band = {};
+        T notch = {};
 
-        T *out;
+        T *out = nullptr;
 
     public:
         StateVariable()


### PR DESCRIPTION
This adds safe zero-default initial values for all class members. 
These defaults will be used in operations such as copy-construction (that don't call the default constructor).

Cleans up the follow warnings:

``` text
../include/../src/libs/mverb/MVerb.h:345:5: warning: ‘Allpass<float, 96000>::Feedback’ should be initialized in the member initialization list [-Weffc++]
../include/../src/libs/mverb/MVerb.h:345:5: warning: ‘Allpass<float, 96000>::Length’ should be initialized in the member initialization list [-Weffc++]
../include/../src/libs/mverb/MVerb.h:345:5: warning: ‘Allpass<float, 96000>::index’ should be initialized in the member initialization list [-Weffc++]
../include/../src/libs/mverb/MVerb.h:402:5: warning: ‘StaticAllpassFourTap<float, 96000>::Feedback’ should be initialized in the member initialization list [-Weffc++]
../include/../src/libs/mverb/MVerb.h:402:5: warning: ‘StaticAllpassFourTap<float, 96000>::Length’ should be initialized in the member initialization list [-Weffc++]
../include/../src/libs/mverb/MVerb.h:402:5: warning: ‘StaticAllpassFourTap<float, 96000>::index1’ should be initialized in the member initialization list [-Weffc++]
../include/../src/libs/mverb/MVerb.h:402:5: warning: ‘StaticAllpassFourTap<float, 96000>::index2’ should be initialized in the member initialization list [-Weffc++]
../include/../src/libs/mverb/MVerb.h:402:5: warning: ‘StaticAllpassFourTap<float, 96000>::index3’ should be initialized in the member initialization list [-Weffc++]
../include/../src/libs/mverb/MVerb.h:402:5: warning: ‘StaticAllpassFourTap<float, 96000>::index4’ should be initialized in the member initialization list [-Weffc++]
../include/../src/libs/mverb/MVerb.h:501:5: warning: ‘StaticDelayLine<float, 96000>::Feedback’ should be initialized in the member initialization list [-Weffc++]
../include/../src/libs/mverb/MVerb.h:501:5: warning: ‘StaticDelayLine<float, 96000>::Length’ should be initialized in the member initialization list [-Weffc++]
../include/../src/libs/mverb/MVerb.h:501:5: warning: ‘StaticDelayLine<float, 96000>::index’ should be initialized in the member initialization list [-Weffc++]
../include/../src/libs/mverb/MVerb.h:549:5: warning: ‘StaticDelayLineFourTap<float, 96000>::Feedback’ should be initialized in the member initialization list [-Weffc++]
../include/../src/libs/mverb/MVerb.h:549:5: warning: ‘StaticDelayLineFourTap<float, 96000>::Length’ should be initialized in the member initialization list [-Weffc++]
../include/../src/libs/mverb/MVerb.h:549:5: warning: ‘StaticDelayLineFourTap<float, 96000>::index1’ should be initialized in the member initialization list [-Weffc++]
../include/../src/libs/mverb/MVerb.h:549:5: warning: ‘StaticDelayLineFourTap<float, 96000>::index2’ should be initialized in the member initialization list [-Weffc++]
../include/../src/libs/mverb/MVerb.h:549:5: warning: ‘StaticDelayLineFourTap<float, 96000>::index3’ should be initialized in the member initialization list [-Weffc++]
../include/../src/libs/mverb/MVerb.h:549:5: warning: ‘StaticDelayLineFourTap<float, 96000>::index4’ should be initialized in the member initialization list [-Weffc++]
../include/../src/libs/mverb/MVerb.h:59:5: warning: ‘MVerb<float>::BandwidthFreq’ should be initialized in the member initialization list [-Weffc++]
../include/../src/libs/mverb/MVerb.h:59:5: warning: ‘MVerb<float>::BandwidthSmooth’ should be initialized in the member initialization list [-Weffc++]
../include/../src/libs/mverb/MVerb.h:59:5: warning: ‘MVerb<float>::ControlRateCounter’ should be initialized in the member initialization list [-Weffc++]
../include/../src/libs/mverb/MVerb.h:59:5: warning: ‘MVerb<float>::ControlRate’ should be initialized in the member initialization list [-Weffc++]
../include/../src/libs/mverb/MVerb.h:59:5: warning: ‘MVerb<float>::DampingFreq’ should be initialized in the member initialization list [-Weffc++]
../include/../src/libs/mverb/MVerb.h:59:5: warning: ‘MVerb<float>::DampingSmooth’ should be initialized in the member initialization list [-Weffc++]
../include/../src/libs/mverb/MVerb.h:59:5: warning: ‘MVerb<float>::DecaySmooth’ should be initialized in the member initialization list [-Weffc++]
../include/../src/libs/mverb/MVerb.h:59:5: warning: ‘MVerb<float>::Decay’ should be initialized in the member initialization list [-Weffc++]
../include/../src/libs/mverb/MVerb.h:59:5: warning: ‘MVerb<float>::Density1’ should be initialized in the member initialization list [-Weffc++]
../include/../src/libs/mverb/MVerb.h:59:5: warning: ‘MVerb<float>::Density2’ should be initialized in the member initialization list [-Weffc++]
../include/../src/libs/mverb/MVerb.h:59:5: warning: ‘MVerb<float>::DensitySmooth’ should be initialized in the member initialization list [-Weffc++]
../include/../src/libs/mverb/MVerb.h:59:5: warning: ‘MVerb<float>::EarlyLateSmooth’ should be initialized in the member initialization list [-Weffc++]
../include/../src/libs/mverb/MVerb.h:59:5: warning: ‘MVerb<float>::EarlyMix’ should be initialized in the member initialization list [-Weffc++]
../include/../src/libs/mverb/MVerb.h:59:5: warning: ‘MVerb<float>::Gain’ should be initialized in the member initialization list [-Weffc++]
../include/../src/libs/mverb/MVerb.h:59:5: warning: ‘MVerb<float>::MixSmooth’ should be initialized in the member initialization list [-Weffc++]
../include/../src/libs/mverb/MVerb.h:59:5: warning: ‘MVerb<float>::Mix’ should be initialized in the member initialization list [-Weffc++]
../include/../src/libs/mverb/MVerb.h:59:5: warning: ‘MVerb<float>::PreDelayTime’ should be initialized in the member initialization list [-Weffc++]
../include/../src/libs/mverb/MVerb.h:59:5: warning: ‘MVerb<float>::PredelaySmooth’ should be initialized in the member initialization list [-Weffc++]
../include/../src/libs/mverb/MVerb.h:59:5: warning: ‘MVerb<float>::PreviousLeftTank’ should be initialized in the member initialization list [-Weffc++]
../include/../src/libs/mverb/MVerb.h:59:5: warning: ‘MVerb<float>::PreviousRightTank’ should be initialized in the member initialization list [-Weffc++]
../include/../src/libs/mverb/MVerb.h:59:5: warning: ‘MVerb<float>::SampleRate’ should be initialized in the member initialization list [-Weffc++]
../include/../src/libs/mverb/MVerb.h:59:5: warning: ‘MVerb<float>::SizeSmooth’ should be initialized in the member initialization list [-Weffc++]
../include/../src/libs/mverb/MVerb.h:59:5: warning: ‘MVerb<float>::Size’ should be initialized in the member initialization list [-Weffc++]
../include/../src/libs/mverb/MVerb.h:59:5: warning: ‘MVerb<float>::predelay’ should be initialized in the member initialization list [-Weffc++]
../include/../src/libs/mverb/MVerb.h:638:5: warning: ‘StaticDelayLineEightTap<float, 96000>::Feedback’ should be initialized in the member initialization list [-Weffc++]
../include/../src/libs/mverb/MVerb.h:638:5: warning: ‘StaticDelayLineEightTap<float, 96000>::Length’ should be initialized in the member initialization list [-Weffc++]
../include/../src/libs/mverb/MVerb.h:638:5: warning: ‘StaticDelayLineEightTap<float, 96000>::index1’ should be initialized in the member initialization list [-Weffc++]
../include/../src/libs/mverb/MVerb.h:638:5: warning: ‘StaticDelayLineEightTap<float, 96000>::index2’ should be initialized in the member initialization list [-Weffc++]
../include/../src/libs/mverb/MVerb.h:638:5: warning: ‘StaticDelayLineEightTap<float, 96000>::index3’ should be initialized in the member initialization list [-Weffc++]
../include/../src/libs/mverb/MVerb.h:638:5: warning: ‘StaticDelayLineEightTap<float, 96000>::index4’ should be initialized in the member initialization list [-Weffc++]
../include/../src/libs/mverb/MVerb.h:638:5: warning: ‘StaticDelayLineEightTap<float, 96000>::index5’ should be initialized in the member initialization list [-Weffc++]
../include/../src/libs/mverb/MVerb.h:638:5: warning: ‘StaticDelayLineEightTap<float, 96000>::index6’ should be initialized in the member initialization list [-Weffc++]
../include/../src/libs/mverb/MVerb.h:638:5: warning: ‘StaticDelayLineEightTap<float, 96000>::index7’ should be initialized in the member initialization list [-Weffc++]
../include/../src/libs/mverb/MVerb.h:638:5: warning: ‘StaticDelayLineEightTap<float, 96000>::index8’ should be initialized in the member initialization list [-Weffc++]
../include/../src/libs/mverb/MVerb.h:770:9: warning: ‘StateVariable<float, 4>::band’ should be initialized in the member initialization list [-Weffc++]
../include/../src/libs/mverb/MVerb.h:770:9: warning: ‘StateVariable<float, 4>::frequency’ should be initialized in the member initialization list [-Weffc++]
../include/../src/libs/mverb/MVerb.h:770:9: warning: ‘StateVariable<float, 4>::f’ should be initialized in the member initialization list [-Weffc++]
../include/../src/libs/mverb/MVerb.h:770:9: warning: ‘StateVariable<float, 4>::high’ should be initialized in the member initialization list [-Weffc++]
../include/../src/libs/mverb/MVerb.h:770:9: warning: ‘StateVariable<float, 4>::low’ should be initialized in the member initialization list [-Weffc++]
../include/../src/libs/mverb/MVerb.h:770:9: warning: ‘StateVariable<float, 4>::notch’ should be initialized in the member initialization list [-Weffc++]
../include/../src/libs/mverb/MVerb.h:770:9: warning: ‘StateVariable<float, 4>::out’ should be initialized in the member initialization list [-Weffc++]
../include/../src/libs/mverb/MVerb.h:770:9: warning: ‘StateVariable<float, 4>::q’ should be initialized in the member initialization list [-Weffc++]
../include/../src/libs/mverb/MVerb.h:770:9: warning: ‘StateVariable<float, 4>::sampleRate’ should be initialized in the member initialization list [-Weffc++]
```